### PR TITLE
password policy: suggest edits

### DIFF
--- a/password/index.md
+++ b/password/index.md
@@ -16,7 +16,9 @@ This policy applies to passwords for any application or server accessed by Tails
 
 Passwords must be unique for each use.
 
-Default passwords on all systems are changed after installation. 
+Passwords must be randomly generated.
+
+Default passwords on all systems are changed after installation. Initial passwords generated for new users must be changed after login.
 
 Passwords do not need to be regularly rotated. However, if a password is known or thought to be compromised, it must be rotated to a new password.
 
@@ -32,11 +34,15 @@ Acceptable forms of multi-factor authentication include authentication apps or a
 
 ### Password manager
 
-Where SSO is not used, and where possible, passwords should be randomly-generated and stored in a password manager.
+Where SSO is not used, and where possible, passwords should be stored in a password manager.
 
 ### Encryption at rest
 
 Passwords should be stored encrypted at rest.
+
+### Logging
+
+Passwords should not be logged.
 
 ### Requirements for specific use cases
 
@@ -46,14 +52,14 @@ Access to servers, for both production as well as development and testing infras
 
 #### Automated processes
 
-Automated processes, including deployment or CI/CD tools, should use passwords or API keys to access and communicate with other systems. These should be encrypted at rest.
+Automated processes, including deployment or CI/CD tools, should use passwords or API keys to access and communicate with other systems. Passwords used in scripts must be encrypted at rest.
 
 #### End user devices
 
-End user devices must use passwords to encrypt their disks and unlock the device. These must be unique for each individual but may be reused across an individual’s devices.
+End user devices must use passwords to encrypt their disks and unlock the device. These must be unique for each individual but may be reused across an individual’s devices. These do not need to be randomly generated.
 
 #### SaaS applications or other software
 
-Access to third party applications must use SSO where possible, MFA where possible, and enforce MFA where possible. Each application must have a randomly-generated password stored in a password manager.
+Access to third party applications must use SSO where possible, MFA where possible, and enforce MFA where possible.
 
-An individual’s password for their password management vault must be unique.
+An individual’s password for their password management vault must be unique. These do not need to be randomly generated.


### PR DESCRIPTION
Based on a contract review with a customer, suggesting edits for a few items that we do today and could make more explicit:
* Do not log or capture passwords when they are entered <- only question here is if we are doing this with Tailscale SSH session recording for certain sessions; if that's the case, can we state these logs are always encrypted at rest and have tight access controls?
* Don't hard code plaintext passwords/ usernames in scripts, files, programs <- already in policy, tried to make more explicit
* Change default passwords <- already in policy
* Change initial passwords for users <- added to the default password section
* Enforce minimum length / strength of passwords <- would prefer not to have specific complexity requirements. Suggested edits re: randomly generated passwords. Suggest we implement minimum defaults in our password manager, if possible, but not add to policy.
